### PR TITLE
Uses errors.Is API to check wrapped errors for their type

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -1,6 +1,7 @@
 package gomodvendor
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -21,11 +22,10 @@ type BuildPlanMetadata struct {
 
 func Detect(goModParser VersionParser) packit.DetectFunc {
 	return func(context packit.DetectContext) (packit.DetectResult, error) {
-
 		version, err := goModParser.ParseVersion(filepath.Join(context.WorkingDir, GoModLocation))
 		if err != nil {
-			if os.IsNotExist(err) {
-				return packit.DetectResult{}, packit.Fail
+			if errors.Is(err, os.ErrNotExist) {
+				return packit.DetectResult{}, packit.Fail.WithMessage("go.mod file is not present")
 			}
 			return packit.DetectResult{}, err
 		}

--- a/detect_test.go
+++ b/detect_test.go
@@ -2,6 +2,7 @@ package gomodvendor_test
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -64,14 +65,14 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	context("go.mod does not exist in the working directory", func() {
 		it.Before(func() {
 			_, err := os.Stat("/no/such/go.mod")
-			goModParser.ParseVersionCall.Returns.Err = err
+			goModParser.ParseVersionCall.Returns.Err = fmt.Errorf("failed to parse go.mod: %w", err)
 		})
 
 		it("fails detection", func() {
 			_, err := detect(packit.DetectContext{
 				WorkingDir: workingDir,
 			})
-			Expect(err).To(MatchError(packit.Fail))
+			Expect(err).To(MatchError(packit.Fail.WithMessage("go.mod file is not present")))
 		})
 	})
 


### PR DESCRIPTION
[`errors.Is`](https://golang.org/pkg/errors/#Is) is the preferred API for checking errors as it will recursively unwrap error objects to find a match. In this case, we were wrapping an error in the parser which then meant that the conditional was no longer triggered and resulted in a stray error instead of a failure when running detection.

This shows up when build a Go app that does user modules:
```
===> DETECTING
[detector] ======== Output: paketo-buildpacks/go-mod-vendor@0.0.166 ========
[detector]
[detector] failed to parse go.mod: open /workspace/go.mod: no such file or directory
[detector] err:  paketo-buildpacks/go-mod-vendor@0.0.166 (1)
```