### PR TITLE
Requires go.mod version >= x.x when specified in go.mod file

### DIFF
--- a/detect_test.go
+++ b/detect_test.go
@@ -39,7 +39,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it.Before(func() {
-		goModParser.ParseVersionCall.Returns.Version = "1.15"
+		goModParser.ParseVersionCall.Returns.Version = ">= 1.15"
 	})
 
 	it("detects", func() {
@@ -54,7 +54,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					Name: "go",
 					Metadata: gomodvendor.BuildPlanMetadata{
 						VersionSource: "go.mod",
-						Version:       "1.15",
+						Version:       ">= 1.15",
 						Build:         true,
 					},
 				},

--- a/go_mod_parser.go
+++ b/go_mod_parser.go
@@ -28,7 +28,7 @@ func (p GoModParser) ParseVersion(path string) (string, error) {
 		matches := re.FindStringSubmatch(scanner.Text())
 
 		if len(matches) == 2 {
-			return fmt.Sprint(matches[1], ".*"), nil
+			return fmt.Sprintf(">= %s", matches[1]), nil
 		}
 	}
 

--- a/go_mod_parser_test.go
+++ b/go_mod_parser_test.go
@@ -48,7 +48,7 @@ require (
 		it("parses the go version from a go.mod file", func() {
 			version, err := parser.ParseVersion(path)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(version).To(Equal("1.15.*"))
+			Expect(version).To(Equal(">= 1.15"))
 		})
 
 		context("failure cases", func() {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
We should be a little bit more permissive in allowing a newer version of Go to be required.

Resolves #164

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have added an integration test, if necessary.
