### PR TITLE
stream `go mod vendor` output

### DIFF
--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -84,6 +84,8 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				"",
 				"  Executing build process",
 				"    Running 'go mod vendor'",
+				MatchRegexp(`      go: downloading github.com/BurntSushi/toml v.+`),
+				MatchRegexp(`      go: downloading github.com/satori/go.uuid v.+`),
 				MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
 				"",
 				"  Generating SBOM for /workspace/go.mod",

--- a/mod_vendor.go
+++ b/mod_vendor.go
@@ -82,7 +82,6 @@ func (m ModVendor) hasModuleGraph(workingDir string) (bool, error) {
 }
 
 func (m ModVendor) Execute(path, workingDir string) error {
-	buffer := bytes.NewBuffer(nil)
 	args := []string{"mod", "vendor"}
 
 	m.logs.Process("Executing build process")
@@ -93,14 +92,12 @@ func (m ModVendor) Execute(path, workingDir string) error {
 			Args:   args,
 			Env:    append(os.Environ(), fmt.Sprintf("GOMODCACHE=%s", path)),
 			Dir:    workingDir,
-			Stdout: buffer,
-			Stderr: buffer,
+			Stdout: m.logs.ActionWriter,
+			Stderr: m.logs.ActionWriter,
 		})
 	})
 	if err != nil {
 		m.logs.Action("Failed after %s", duration.Round(time.Millisecond))
-		m.logs.Detail(buffer.String())
-
 		return err
 	}
 

--- a/mod_vendor_test.go
+++ b/mod_vendor_test.go
@@ -161,6 +161,13 @@ func testModVendor(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	context("Execute", func() {
+		it.Before(func() {
+			executable.ExecuteCall.Stub = func(execution pexec.Execution) error {
+				fmt.Fprintln(execution.Stdout, "stdout-output")
+				fmt.Fprintln(execution.Stderr, "stderr-output")
+				return nil
+			}
+		})
 		it("runs go mod vendor", func() {
 			err := modVendor.Execute("mod-cache-path", workingDir)
 			Expect(err).NotTo(HaveOccurred())
@@ -170,6 +177,8 @@ func testModVendor(t *testing.T, context spec.G, it spec.S) {
 
 			Expect(logs.String()).To(ContainSubstring("  Executing build process"))
 			Expect(logs.String()).To(ContainSubstring("    Running 'go mod vendor'"))
+			Expect(logs.String()).To(ContainSubstring("      stdout-output"))
+			Expect(logs.String()).To(ContainSubstring("      stderr-output"))
 			Expect(logs.String()).To(ContainSubstring("      Completed in 1s"))
 		})
 
@@ -188,9 +197,9 @@ func testModVendor(t *testing.T, context spec.G, it spec.S) {
 					err := modVendor.Execute("mod-cache-path", workingDir)
 					Expect(err).To(MatchError(ContainSubstring("executable failed")))
 
+					Expect(logs.String()).To(ContainSubstring("      build error stdout"))
+					Expect(logs.String()).To(ContainSubstring("      build error stderr"))
 					Expect(logs.String()).To(ContainSubstring("      Failed after 1s"))
-					Expect(logs.String()).To(ContainSubstring("        build error stdout"))
-					Expect(logs.String()).To(ContainSubstring("        build error stderr"))
 				})
 			})
 		})


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Leverage the `packit scribe.LogEmitter` writer to stream `go mod vendor` logs in real-time.
The outcome will be logs that look like this:

```
[builder] Paketo Buildpack for Go Mod Vendor 1.2.3
[builder]   Checking module graph
[builder]     Running 'go mod graph'
[builder]       Completed in 219ms
[builder]
[builder]   Executing build process
[builder]     Running 'go mod vendor'
[builder]       go: downloading github.com/satori/go.uuid v1.1.0
[builder]       go: downloading github.com/BurntSushi/toml v0.3.1
[builder]       Completed in 356ms
```

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
